### PR TITLE
Add parallel compilation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,10 @@
 - name: Update APT cache
   apt: update_cache=yes
 
+- name: Number of cores
+  command: nproc
+  register: cores
+
 - name: Install prerequisite packages that are necessary to compile applications and gems with native extensions
   apt: pkg={{ item }}
   with_items:

--- a/templates/install-ruby.j2
+++ b/templates/install-ruby.j2
@@ -3,6 +3,6 @@
 cd /usr/local/src/
 tar xvfz {{ ruby_version }}.tar.gz
 cd {{ ruby_version }}
-./configure --prefix={{ ruby_location }}
-make
+./configure --prefix={{ ruby_location }} --disable-install-doc
+make --jobs {{ cores.stdout }}
 make install


### PR DESCRIPTION
This passes the `--jobs` flag to `make` which allows it to compile files in parallel. On large machines, this can cut down the compilation time many, many times. It receives the number of cores from running `nproc`, which obeys to the role being compatible with Debian and Ubuntu. Parallel compilation of Ruby is entirely safe (e.g. `ruby-build` does it by default).

Also adds `--disable-install-doc` which disables generating `ri` and `rdoc` documentation which is not particularly useful in deployment settings.

I've tested this with a local Vagrant and it appears to work!
